### PR TITLE
Strip BOM for CSV file exported from Excel

### DIFF
--- a/tagger/tagger.py
+++ b/tagger/tagger.py
@@ -153,6 +153,9 @@ class CSVResourceTagger(object):
     def _parse_header(self, header_row):
         tag_index = {}
         for index, name in enumerate(header_row):
+            # Handle BOM.
+            if index == 0:
+                name = name.lstrip('\ufeff')            
             tag_index[name] = index
 
         return tag_index


### PR DESCRIPTION
If the BOM is not removed, matching on `tag_index[self.resource_id_column]` lookup fails.

Signed-off-by: Byron Ruth <b@devel.io>