### PR TITLE
Resource tagging for CSV files with mention of tag value pairs at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ echo 'i-22222222,us-east-1,Foobar' >> my-resources.csv
 aws-tagger --csv my-resources.csv
 ```
 
+### Tag multiple resources from a CSV file with no need to specify tags in CSV file 
+AS AWS Tagger can take input from CSV file but for now, one has to spcify the tag values within the csv file. The support is extended for cases where resource ids and regions need to be sourced from CSV file and bulk tagging needs to be done for all resources,e.g. specify a single tag value for all resources present in CSV file.
+
+```
+python cli.py --csv my-resources.csv --tag "tag:value"
+```
+
 ## AWS Resource Support
 AWS Tagger supports the following AWS resource types. 
 

--- a/tagger/cli.py
+++ b/tagger/cli.py
@@ -15,8 +15,9 @@ from pprint import pprint
 @click.option('--csv', help='CSV file to read data from.')
 def cli(dryrun, verbose, region, role, resource, tag, csv):
     if csv and (len(resource) > 0 or len(tag) > 0):
-        print("Cannot use --resource or --tag with --csv option")
-        sys.exit(1)
+        tagger = CSVResourceTaggerWithTags(dryrun, verbose, role, region, tag_volumes=True)
+        tags = _tag_options_to_dict(tag)
+        tagger.tag(csv, tags)
     if csv:
         tagger = CSVResourceTagger(dryrun, verbose, role, region, tag_volumes=True)
         tagger.tag(csv)


### PR DESCRIPTION
Earlier, the aws-tagger package doesn't support specifying tags within command line for CSV file. The tag value pairs have to defined within the CSV file. Now no need to specify similar tags for all resources within csv file and it can be specified during runtime attached with "--tag" flag.